### PR TITLE
Fix output timestamps when inputing a '.sup' file

### DIFF
--- a/src/mkvUtil.cpp
+++ b/src/mkvUtil.cpp
@@ -112,7 +112,7 @@ std::vector<supStream> mkvUtil::extractSelectMKVsup(std::string filename, std::v
 			entry = av_dict_get(mkvFile->streams[tracks[i]]->metadata, "title", entry, AV_DICT_IGNORE_SUFFIX);
 			title += entry == NULL ? language : entry->value;
 			//offset = mkvFile->streams[tracks[i]]->start_time;
-			time_base.num = mkvFile->streams[tracks[i]]->time_base.num;
+			time_base.num = mkvFile->streams[tracks[i]]->time_base.num * 90;
 			time_base.den = mkvFile->streams[tracks[i]]->time_base.den;
 			streams.insert(std::pair<unsigned int, supStream>(tracks[i], supStream(tracks[i], language, title, base_offset, time_base)));
 		}
@@ -135,7 +135,7 @@ std::vector<supStream> mkvUtil::extractSelectMKVsup(std::string filename, std::v
 				time(&now);
 				if (now - last_time >= 1)
 				{
-					std::cout << "\rParsing mkv at: " + mkvUtil::milliToString((packet->pts - streams[packet->stream_index].offset) * streams[packet->stream_index].time_base.num * 1000 / streams[packet->stream_index].time_base.den);
+					std::cout << "\rParsing mkv at: " + mkvUtil::milliToString((packet->pts - streams[packet->stream_index].offset) * (streams[packet->stream_index].time_base.num / 90) * 1000 / streams[packet->stream_index].time_base.den);
 					std::cout.flush();
 					last_time = now;
 				}

--- a/src/srtUtil.cpp
+++ b/src/srtUtil.cpp
@@ -39,8 +39,8 @@ void srtUtil::pgsToSRTFile(pgsParser * pgs, const char* output, const char* lang
 	{
 		if(pgs->displaySegments[i].ods.size()==1 && pgs->displaySegments[i].pds.size()==1)
 		{
-			std::string start = srtUtil::milliToSRTString(pgs->displaySegments[i].pcs.HEADER.PRESENTATION_TIMESTAMP);
-			std::string end = srtUtil::milliToSRTString(pgs->displaySegments[i+1].pcs.HEADER.PRESENTATION_TIMESTAMP);
+			std::string start = srtUtil::milliToSRTString(pgs->displaySegments[i].pcs.HEADER.PRESENTATION_TIMESTAMP/90);
+			std::string end = srtUtil::milliToSRTString(pgs->displaySegments[i+1].pcs.HEADER.PRESENTATION_TIMESTAMP/90);
 			std::ostringstream data = pgs->displaySegments[i].getClearTIFF();
 			Pix * pix = pixReadMem(reinterpret_cast<const unsigned char *>(data.str().c_str()), data.str().length());
 			data.clear();


### PR DESCRIPTION
Seems like [c7360cc](https://github.com/retrontology/sup2srt/commit/c7360ccfed21479f0fb0ff82108b7049c74fe717#diff-c2647c5d01845ee951c86b79f7f6d3308592026997ac07a64022c8f2d3e4e38dL49) broke the ability to use a binary `.sup` as input, since it causes the srt timestamps to be way longer than normal.

I feel that this is kinda hacky, but it's the best I can come up with that makes both `.mkv` and `.sup` input work properly.