### PR TITLE
portability: use portable headers and add missing one.

### DIFF
--- a/src/mkvUtil.cpp
+++ b/src/mkvUtil.cpp
@@ -1,8 +1,10 @@
+#include <fstream>
 #include "mkvUtil.h"
 #include "pgs/pgsUtil.h"
 #include <map>
 #include <utility>
 #include <iostream>
+#include <iomanip>
 #include <time.h> 
 
 std::map<std::string,std::string> isoMap::map

--- a/src/pgs/displaySegment.cpp
+++ b/src/pgs/displaySegment.cpp
@@ -9,6 +9,7 @@
 #include <tiffio.hxx>
 #include <sstream>
 #include <iostream>
+#include <cstring>
 #include "displaySegment.h"
 #include "pgsUtil.h"
 

--- a/src/pgs/pgsParser.cpp
+++ b/src/pgs/pgsParser.cpp
@@ -4,8 +4,8 @@
  *  Created on: Nov 1, 2020
  *      Author: blazer
  */
+#include <iomanip>
 #include <fstream>
-#include <bits/stdc++.h>
 #include <string>
 #include <stdlib.h>
 #include <vector>

--- a/src/pgs/pgsUtil.cpp
+++ b/src/pgs/pgsUtil.cpp
@@ -8,7 +8,6 @@
 #include "pgsUtil.h"
 #include "pgsSegment.h"
 #include <iostream>
-#include <bits/stdc++.h>
 #include <fstream>
 
 unsigned long int pgsUtil::char4ToLong(char * ptr)

--- a/src/pgs/pgsUtil.h
+++ b/src/pgs/pgsUtil.h
@@ -9,7 +9,6 @@
 #define PGSUTIL_H_
 
 #include "pgsSegment.h"
-#include <bits/stdc++.h>
 #include "objectDefinitionSegment.h"
 #include "paletteDefinitionSegment.h"
 


### PR DESCRIPTION
bits/stdc++.h is not portable, instead use portable headers: iomanip for std::setw and std::setfill.

While here add missing fstream header where needed

This makes the project build with clang and libc++ on FreeBSD