### PR TITLE
don't use root user, and use lean runtime only deps

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+case "$1" in
+    sup2disk)
+        shift
+        exec /app/sup2disk "$@"
+        ;;
+    sup2srt)
+        shift
+        exec /app/sup2srt "$@"
+        ;;
+    *)
+        exec /app/sup2srt "$@"
+        ;;
+esac


### PR DESCRIPTION
- uses lean runtime only dependencies (where possible)
- allows user to specify languages during docker build phase `docker build . -t harbor.garb.dev/library/sup2srt --build-arg=TESSERACT_LANGS="eng spa"`

I see that you aren't publishing this image, if you're interested, I could commit a docker workflow to your repository and I suggest the english language only.

Let me know