### PR TITLE
chore(updates): use ubuntu:26.04 and remove headers in final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest AS builder
+FROM ubuntu:26.04 AS builder
 WORKDIR /app
 
 RUN apt-get update && \
@@ -32,7 +32,7 @@ RUN mkdir build && \
     make -j8 && \
     make install
 
-FROM ubuntu:latest
+FROM ubuntu:26.04
 
 WORKDIR /app
 
@@ -43,14 +43,14 @@ ARG TESSERACT_LANGS="eng"
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    libtiff-dev \
-    libleptonica-dev \
     libtiff6 \
-    libavcodec60 \
-    libavformat60 \
-    libavutil58 \
+    libtiffxx6 \
+    libleptonica6 \
+    libavcodec62 \
+    libavformat62 \
+    libavutil60 \
     libtesseract5 \
-    $(echo $TESSERACT_LANGS | sed 's/\([^ ]\+\)/tesseract-ocr-\1/g') && \
+    $(echo "$TESSERACT_LANGS" | sed 's/\([^ ]\+\)/tesseract-ocr-\1/g') && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /app && chown -R ubuntu:ubuntu /app


### PR DESCRIPTION
- use 
```
libtiff6 \
libtiffxx6 \
```
libraries c and c++ runtime

- use pinned ubuntu version (26.04) so latest doesn't break if majors/minors of runtimes are released

NOTE: hopefully, i'll only need to keep patching my initial crappy dockerfile every 2y, or we update using dependabot / renovate here, if you're interested in that I can add support, you can create an issue and assign to me :) 

thanks for this software btw